### PR TITLE
Fix mixed content issue by using HTTPS for Steam API

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@
             API_KEY: '274411C2579E7E7CB7482A4BDEAB1077',
             PROXY_URL: 'https://corsproxy.io/?',
             STORE_BASE: 'https://store.steampowered.com/app',
-            API_BASE: 'http://api.steampowered.com'
+            API_BASE: 'https://api.steampowered.com'
         };
 
         // 共享帳號


### PR DESCRIPTION
## Summary
- switch Steam API base from `http` to `https`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6866ace4cca88328a95df35baf49b965